### PR TITLE
Fix jsPDF autoTable function error

### DIFF
--- a/lib/reports/jspdf-export.ts
+++ b/lib/reports/jspdf-export.ts
@@ -1,12 +1,5 @@
-import { jsPDF } from "jspdf";
-import "jspdf-autotable";
-
-// Extend jsPDF type to include autoTable
-declare module "jspdf" {
-  interface jsPDF {
-    autoTable: (options: any) => jsPDF;
-  }
-}
+import jsPDF from "jspdf";
+import autoTable, { UserOptions } from "jspdf-autotable";
 
 interface MenuReportData {
   type: string;
@@ -112,7 +105,8 @@ export function createMenuReportPDFWithJsPDF(
         ])
       : [['No data available for this date', '', '', '', '', '']];
 
-    doc.autoTable({
+    // Use the imported autoTable function
+    autoTable(doc, {
       head: [['Kitchen', 'Recipe', 'Meal Type', 'Servings', 'Status', 'Notes']],
       body: tableData,
       startY: yPosition,
@@ -150,7 +144,8 @@ export function createMenuReportPDFWithJsPDF(
         ])
       : [['No data available for this date', '', '', '', '']];
 
-    doc.autoTable({
+    // Use the imported autoTable function
+    autoTable(doc, {
       head: [['Kitchen', 'Recipe', 'Servings', 'Ghan Factor', 'Status']],
       body: tableData,
       startY: yPosition,


### PR DESCRIPTION
Fix `autoTable is not a function` error by correctly importing and using `jspdf-autotable` as a standalone function.

The original implementation attempted to extend `jsPDF` directly and relied on a side-effect import for `jspdf-autotable`, which caused a runtime error because the `autoTable` method was not properly attached to the `jsPDF` instance. This PR updates the import to use `autoTable` as a named import and calls it as a standalone function (`autoTable(doc, options)`), which is the recommended and correct way to integrate `jspdf-autotable` with `jsPDF` in a TypeScript environment. This resolves the runtime error and ensures proper type safety.

---
<a href="https://cursor.com/background-agent?bcId=bc-b890e8be-4a3d-4073-a34f-25eb50626ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b890e8be-4a3d-4073-a34f-25eb50626ceb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>