### PR TITLE
Fetch and display recipe details by id

### DIFF
--- a/app/api/recipes/[id]/route.ts
+++ b/app/api/recipes/[id]/route.ts
@@ -1,0 +1,118 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    console.log(`Fetching recipe with ID: ${params.id}`);
+
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const recipe = await prisma.recipe.findUnique({
+      where: {
+        id: params.id,
+      },
+      include: {
+        ingredients: {
+          select: {
+            id: true,
+            name: true,
+            quantity: true,
+            unit: true,
+            costPerUnit: true,
+          },
+          orderBy: {
+            name: "asc",
+          },
+        },
+        user: {
+          select: {
+            name: true,
+            email: true,
+          },
+        },
+        _count: {
+          select: {
+            menus: true,
+          },
+        },
+      },
+    });
+
+    if (!recipe) {
+      return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
+    }
+
+    console.log(`Found recipe: ${recipe.name} with ${recipe.ingredients.length} ingredients`);
+    return NextResponse.json(recipe);
+  } catch (error) {
+    console.error("Get recipe by ID API error:", error);
+    return NextResponse.json(
+      { error: "Failed to fetch recipe" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    console.log(`Deleting recipe with ID: ${params.id}`);
+
+    const session = await getServerSession(authOptions);
+
+    if (!session?.user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    // Check if recipe exists and user has permission to delete it
+    const existingRecipe = await prisma.recipe.findUnique({
+      where: { id: params.id },
+      select: { 
+        userId: true,
+        name: true,
+      },
+    });
+
+    if (!existingRecipe) {
+      return NextResponse.json({ error: "Recipe not found" }, { status: 404 });
+    }
+
+    // Check if user owns this recipe or is admin
+    if (
+      existingRecipe.userId !== session.user.id &&
+      session.user.role !== "ADMIN"
+    ) {
+      return NextResponse.json(
+        { error: "Unauthorized to delete this recipe" },
+        { status: 403 },
+      );
+    }
+
+    // Delete the recipe (ingredients will be deleted automatically due to cascade)
+    await prisma.recipe.delete({
+      where: { id: params.id },
+    });
+
+    console.log(`Successfully deleted recipe: ${existingRecipe.name}`);
+    return NextResponse.json({ message: "Recipe deleted successfully" });
+  } catch (error) {
+    console.error("Delete recipe API error:", error);
+    return NextResponse.json(
+      { error: "Failed to delete recipe" },
+      { status: 500 },
+    );
+  }
+}

--- a/app/recipes/[id]/page.tsx
+++ b/app/recipes/[id]/page.tsx
@@ -24,7 +24,7 @@ export default function RecipeDetailPage() {
 
       try {
         setLoading(true);
-        const response = await fetch(`/api/recipes?id=${recipeId}`);
+        const response = await fetch(`/api/recipes/${recipeId}`);
         
         if (!response.ok) {
           throw new Error('Failed to fetch recipe');
@@ -41,16 +41,15 @@ export default function RecipeDetailPage() {
           servings: detailedRecipe.servings,
           category: detailedRecipe.category,
           subcategory: detailedRecipe.subcategory,
-          cost: detailedRecipe.cost,
-          ingredients: detailedRecipe.ingredients?.map((ri: any) => ({
-            id: ri.ingredient?.id || ri.id,
-            name: ri.ingredient?.name || ri.name,
-            quantity: ri.quantity,
-            unit: ri.ingredient?.unit || ri.unit,
-            costPerUnit: ri.ingredient?.costPerUnit || ri.costPerUnit,
+          ingredients: detailedRecipe.ingredients?.map((ingredient: any) => ({
+            id: ingredient.id,
+            name: ingredient.name,
+            quantity: ingredient.quantity,
+            unit: ingredient.unit,
+            costPerUnit: ingredient.costPerUnit,
           })) || [],
-          createdAt: detailedRecipe.createdAt,
-          updatedAt: detailedRecipe.updatedAt,
+          createdAt: detailedRecipe.createdAt ? new Date(detailedRecipe.createdAt) : undefined,
+          updatedAt: detailedRecipe.updatedAt ? new Date(detailedRecipe.updatedAt) : undefined,
         };
 
         setRecipe(recipeData);

--- a/app/recipes/page.tsx
+++ b/app/recipes/page.tsx
@@ -85,7 +85,7 @@ export default function RecipesPage() {
   const handlePrintRecipe = async (recipe: Recipe) => {
     try {
       // Fetch detailed recipe data from API
-      const response = await fetch(`/api/recipes?id=${recipe.id}`);
+      const response = await fetch(`/api/recipes/${recipe.id}`);
       if (!response.ok) {
         throw new Error('Failed to fetch recipe details');
       }
@@ -101,16 +101,15 @@ export default function RecipesPage() {
         servings: detailedRecipe.servings,
         category: detailedRecipe.category,
         subcategory: detailedRecipe.subcategory,
-        cost: detailedRecipe.cost,
-        ingredients: detailedRecipe.ingredients?.map((ri: any) => ({
-          id: ri.ingredient?.id || ri.id,
-          name: ri.ingredient?.name || ri.name,
-          quantity: ri.quantity,
-          unit: ri.ingredient?.unit || ri.unit,
-          costPerUnit: ri.ingredient?.costPerUnit || ri.costPerUnit,
+        ingredients: detailedRecipe.ingredients?.map((ingredient: any) => ({
+          id: ingredient.id,
+          name: ingredient.name,
+          quantity: ingredient.quantity,
+          unit: ingredient.unit,
+          costPerUnit: ingredient.costPerUnit,
         })) || [],
-        createdAt: detailedRecipe.createdAt,
-        updatedAt: detailedRecipe.updatedAt,
+        createdAt: detailedRecipe.createdAt ? new Date(detailedRecipe.createdAt) : undefined,
+        updatedAt: detailedRecipe.updatedAt ? new Date(detailedRecipe.updatedAt) : undefined,
       };
 
       setSelectedRecipeForPrint(recipeData);
@@ -144,7 +143,7 @@ export default function RecipesPage() {
   const handleDeleteRecipe = async (id: string) => {
     setDeletingId(id);
     try {
-      const response = await fetch(`/api/recipes?id=${id}`, {
+      const response = await fetch(`/api/recipes/${id}`, {
         method: "DELETE",
       });
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adds a dedicated API route for fetching and deleting individual recipes by ID to fix the blank recipe details view.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous `/api/recipes` endpoint did not support fetching individual recipes by ID, causing the recipe details page to appear blank. This PR introduces a new API route (`/api/recipes/[id]`) to correctly fetch and delete specific recipe data, ensuring the details view and print functionality work as expected.

---
<a href="https://cursor.com/background-agent?bcId=bc-44d5dc1c-d7cc-4d36-8fa0-5b1fc2f8d51b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-44d5dc1c-d7cc-4d36-8fa0-5b1fc2f8d51b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>