### PR TITLE
Migrate all date handling to date-fns

### DIFF
--- a/app/api/menus/route.ts
+++ b/app/api/menus/route.ts
@@ -2,6 +2,7 @@ import { authOptions } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { getServerSession } from "next-auth";
 import { NextResponse } from "next/server";
+import { parseISOString, createStartOfDayUTC, createEndOfDayUTC, getCurrentDateUTC } from "@/lib/utils/date";
 
 export const dynamic = "force-dynamic";
 
@@ -77,11 +78,10 @@ export async function GET(request: Request) {
     }
 
     if (date) {
-      const targetDate = new Date(date);
-      const startOfDay = new Date(targetDate);
-      startOfDay.setHours(0, 0, 0, 0);
-      const endOfDay = new Date(targetDate);
-      endOfDay.setHours(23, 59, 59, 999);
+      // Parse date string and create UTC day boundaries for database queries
+      const targetDate = parseISOString(date);
+      const startOfDay = createStartOfDayUTC(targetDate);
+      const endOfDay = createEndOfDayUTC(targetDate);
 
       where.date = {
         gte: startOfDay,
@@ -174,9 +174,9 @@ export async function POST(request: Request) {
       );
     }
 
-    // Ensure date is properly formatted
+    // Ensure date is properly formatted (parse to UTC Date for storage)
     if (data.date) {
-      data.date = new Date(data.date);
+      data.date = parseISOString(data.date.toString());
     }
 
     // Extract ingredients from data

--- a/components/ui/compact-date-selector.tsx
+++ b/components/ui/compact-date-selector.tsx
@@ -8,16 +8,19 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
-import { addDays, format, subDays } from "date-fns";
+import { addTime, subtractTime, formatForStorage, getLocalTimezone } from "@/lib/utils/date";
+import { format } from "date-fns";
+import { formatInTimeZone } from "date-fns-tz";
 import { Calendar, ChevronLeft, ChevronRight } from "lucide-react";
 import { useEffect, useState } from "react";
 import { DatePicker } from "./date-picker";
 
 interface CompactDateSelectorProps {
-  date?: Date;
-  onDateChange?: (date: Date) => void;
+  date?: Date; // UTC Date for storage
+  onDateChange?: (date: Date) => void; // Returns UTC Date for storage
   className?: string;
   kitchenId?: string;
+  timezone?: string; // IANA timezone for display (defaults to user's local)
 }
 
 export function CompactDateSelector({
@@ -25,9 +28,11 @@ export function CompactDateSelector({
   onDateChange,
   className,
   kitchenId,
+  timezone,
 }: CompactDateSelectorProps) {
+  const userTimezone = timezone || getLocalTimezone();
   const [selectedDate, setSelectedDate] = useState<Date>(
-    initialDate || new Date(),
+    initialDate || new Date(), // Store in UTC
   );
   const [isCalendarOpen, setIsCalendarOpen] = useState(false);
   const [currentEventInfo, setCurrentEventInfo] = useState<{
@@ -39,7 +44,7 @@ export function CompactDateSelector({
   useEffect(() => {
     const fetchTithiInfo = async () => {
       try {
-        const dateStr = selectedDate.toISOString().split("T")[0];
+        const dateStr = formatForStorage(selectedDate).split("T")[0];
         const params = new URLSearchParams({
           date: dateStr,
           ...(kitchenId && { kitchenId }),
@@ -71,12 +76,12 @@ export function CompactDateSelector({
   };
 
   const goToPreviousDay = () => {
-    const newDate = subDays(selectedDate, 1);
+    const newDate = subtractTime.days(selectedDate, 1);
     handleDateChange(newDate);
   };
 
   const goToNextDay = () => {
-    const newDate = addDays(selectedDate, 1);
+    const newDate = addTime.days(selectedDate, 1);
     handleDateChange(newDate);
   };
 
@@ -88,15 +93,15 @@ export function CompactDateSelector({
   };
 
   const formatDate = (date: Date) => {
-    return format(date, "EEEE, dd MMM yyyy");
+    return formatInTimeZone(date, userTimezone, "EEEE, dd MMM yyyy");
   };
 
   const formatShortDate = (date: Date) => {
-    return format(date, "dd MMM");
+    return formatInTimeZone(date, userTimezone, "dd MMM");
   };
 
   const formatDay = (date: Date) => {
-    return format(date, "EEEE");
+    return formatInTimeZone(date, userTimezone, "EEEE");
   };
 
   // Determine what to show as subtitle

--- a/hooks/use-tithi.ts
+++ b/hooks/use-tithi.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { formatForStorage, getCurrentDateUTC } from "@/lib/utils/date";
 
 interface TithiInfo {
   tithi?: string;
@@ -19,8 +20,8 @@ export function useTithi(date?: Date, kitchenId?: string): TithiInfo {
       setTithiInfo((prev) => ({ ...prev, isLoading: true, error: undefined }));
 
       try {
-        const targetDate = date || new Date();
-        const dateStr = targetDate.toISOString().split("T")[0];
+        const targetDate = date || getCurrentDateUTC(); // Use UTC for consistency
+        const dateStr = formatForStorage(targetDate).split("T")[0];
 
         const params = new URLSearchParams({
           date: dateStr,
@@ -65,5 +66,5 @@ export function useTithi(date?: Date, kitchenId?: string): TithiInfo {
 }
 
 export function useTodayTithi(kitchenId?: string): TithiInfo {
-  return useTithi(new Date(), kitchenId);
+  return useTithi(getCurrentDateUTC(), kitchenId); // Use UTC current date
 }

--- a/lib/actions/home.ts
+++ b/lib/actions/home.ts
@@ -2,6 +2,7 @@
 
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
+import { createStartOfDayUTC, createEndOfDayUTC, getCurrentDateUTC, subtractTime } from "@/lib/utils/date";
 
 export async function getHomeStats() {
   try {
@@ -18,19 +19,16 @@ export async function getHomeStats() {
       };
     }
 
-    const today = new Date();
-    const yesterday = new Date(today);
-    yesterday.setDate(yesterday.getDate() - 1);
+    // Use UTC dates for consistent server-side operations
+    const today = getCurrentDateUTC();
+    const yesterday = subtractTime.days(today, 1);
 
-    const startOfToday = new Date(today);
-    startOfToday.setHours(0, 0, 0, 0);
-    const endOfToday = new Date(today);
-    endOfToday.setHours(23, 59, 59, 999);
+    // Use date-fns for consistent day boundary handling in UTC
+    const startOfToday = createStartOfDayUTC(today);
+    const endOfToday = createEndOfDayUTC(today);
 
-    const startOfYesterday = new Date(yesterday);
-    startOfYesterday.setHours(0, 0, 0, 0);
-    const endOfYesterday = new Date(yesterday);
-    endOfYesterday.setHours(23, 59, 59, 999);
+    const startOfYesterday = createStartOfDayUTC(yesterday);
+    const endOfYesterday = createEndOfDayUTC(yesterday);
 
     const whereClause: any = {};
 

--- a/lib/actions/menu.ts
+++ b/lib/actions/menu.ts
@@ -3,6 +3,7 @@
 import { auth } from "@/lib/auth";
 import { prisma } from "@/lib/prisma";
 import { revalidatePath } from "next/cache";
+import { createStartOfDayUTC, createEndOfDayUTC, getCurrentDateUTC } from "@/lib/utils/date";
 
 export async function getDailyMenus(date?: Date, kitchenId?: string) {
   try {
@@ -12,18 +13,16 @@ export async function getDailyMenus(date?: Date, kitchenId?: string) {
       return {};
     }
 
-    const targetDate = date || new Date();
+    const targetDate = date || getCurrentDateUTC(); // Use UTC for consistency
     const targetKitchenId = kitchenId || session.user.kitchenId;
 
     if (!targetKitchenId) {
       return {};
     }
 
-    const startOfDay = new Date(targetDate);
-    startOfDay.setHours(0, 0, 0, 0);
-
-    const endOfDay = new Date(targetDate);
-    endOfDay.setHours(23, 59, 59, 999);
+    // Use date-fns for consistent day boundary handling in UTC
+    const startOfDay = createStartOfDayUTC(targetDate);
+    const endOfDay = createEndOfDayUTC(targetDate);
 
     const menus = await prisma.menu.findMany({
       where: {

--- a/lib/utils/__tests__/date.test.ts
+++ b/lib/utils/__tests__/date.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for date-fns migration
+ * These tests verify that our date utilities work correctly across timezones
+ */
+
+import {
+  formatEpochToDate,
+  formatEpochToTime,
+  dateToEpoch,
+  getLocalTimezone,
+  getCurrentDateUTC,
+  getCurrentEpoch,
+  epochToDate,
+  getNextDay,
+  getPreviousDay,
+  formatTimeAgo,
+  createStartOfDayUTC,
+  createEndOfDayUTC,
+  formatForStorage,
+  formatForDisplay,
+  parseISOString,
+  isSameDate,
+  addTime,
+  subtractTime,
+  dateDifference,
+} from '../date';
+import { formatInTimeZone } from 'date-fns-tz';
+
+describe('Date Utils Migration Tests', () => {
+  const testDate = new Date('2024-01-15T12:30:45.123Z'); // UTC date
+  const testEpoch = testDate.getTime();
+
+  describe('Basic Date Operations', () => {
+    test('epochToDate converts correctly', () => {
+      expect(epochToDate(testEpoch)).toEqual(testDate);
+      expect(epochToDate(testEpoch / 1000)).toEqual(testDate); // seconds to ms
+    });
+
+    test('dateToEpoch converts correctly', () => {
+      expect(dateToEpoch(testDate)).toBe(testEpoch);
+      expect(dateToEpoch('2024-01-15T12:30:45.123Z')).toBe(testEpoch);
+    });
+
+    test('parseISOString works correctly', () => {
+      const parsed = parseISOString('2024-01-15T12:30:45.123Z');
+      expect(parsed.getTime()).toBe(testEpoch);
+    });
+  });
+
+  describe('Timezone Handling', () => {
+    test('formatEpochToDate respects timezone', () => {
+      const utcFormat = formatEpochToDate(testEpoch, 'yyyy-MM-dd', 'UTC');
+      const nyFormat = formatEpochToDate(testEpoch, 'yyyy-MM-dd', 'America/New_York');
+      
+      expect(utcFormat).toBe('2024-01-15');
+      // NY is UTC-5 in January, so same date but different time context
+      expect(nyFormat).toBe('2024-01-15');
+    });
+
+    test('formatEpochToTime respects timezone', () => {
+      const utcTime = formatEpochToTime(testEpoch, 'HH:mm', false, 'UTC');
+      const nyTime = formatEpochToTime(testEpoch, 'HH:mm', false, 'America/New_York');
+      
+      expect(utcTime).toBe('12:30');
+      expect(nyTime).toBe('07:30'); // UTC-5
+    });
+
+    test('formatForDisplay uses user timezone', () => {
+      const formatted = formatForDisplay(testDate, 'PPP', 'Asia/Kolkata');
+      // Should format in IST (UTC+5:30)
+      expect(formatted).toContain('January 15th, 2024');
+    });
+  });
+
+  describe('Date Arithmetic', () => {
+    test('addTime functions work correctly', () => {
+      const nextDay = addTime.days(testDate, 1);
+      const nextHour = addTime.hours(testDate, 1);
+      
+      expect(nextDay.getDate()).toBe(testDate.getDate() + 1);
+      expect(nextHour.getHours()).toBe(testDate.getHours() + 1);
+    });
+
+    test('subtractTime functions work correctly', () => {
+      const prevDay = subtractTime.days(testDate, 1);
+      const prevHour = subtractTime.hours(testDate, 1);
+      
+      expect(prevDay.getDate()).toBe(testDate.getDate() - 1);
+      expect(prevHour.getHours()).toBe(testDate.getHours() - 1);
+    });
+
+    test('dateDifference functions work correctly', () => {
+      const laterDate = addTime.days(testDate, 5);
+      
+      expect(dateDifference.inDays(laterDate, testDate)).toBe(5);
+      expect(dateDifference.inHours(laterDate, testDate)).toBe(5 * 24);
+    });
+  });
+
+  describe('Day Boundaries', () => {
+    test('createStartOfDayUTC creates correct boundary', () => {
+      const startOfDay = createStartOfDayUTC(testDate);
+      
+      expect(startOfDay.getUTCHours()).toBe(0);
+      expect(startOfDay.getUTCMinutes()).toBe(0);
+      expect(startOfDay.getUTCSeconds()).toBe(0);
+      expect(startOfDay.getUTCMilliseconds()).toBe(0);
+    });
+
+    test('createEndOfDayUTC creates correct boundary', () => {
+      const endOfDay = createEndOfDayUTC(testDate);
+      
+      expect(endOfDay.getUTCHours()).toBe(23);
+      expect(endOfDay.getUTCMinutes()).toBe(59);
+      expect(endOfDay.getUTCSeconds()).toBe(59);
+      expect(endOfDay.getUTCMilliseconds()).toBe(999);
+    });
+  });
+
+  describe('Helper Functions', () => {
+    test('getNextDay and getPreviousDay work correctly', () => {
+      const next = getNextDay(testDate);
+      const prev = getPreviousDay(testDate);
+      
+      expect(dateDifference.inDays(next, testDate)).toBe(1);
+      expect(dateDifference.inDays(testDate, prev)).toBe(1);
+    });
+
+    test('isSameDate works correctly', () => {
+      const sameDay = new Date('2024-01-15T23:59:59.999Z');
+      const differentDay = new Date('2024-01-16T00:00:00.000Z');
+      
+      expect(isSameDate(testDate, sameDay)).toBe(true);
+      expect(isSameDate(testDate, differentDay)).toBe(false);
+    });
+
+    test('formatTimeAgo works correctly', () => {
+      const fiveMinutesAgo = subtractTime.minutes(getCurrentDateUTC(), 5);
+      const timeAgo = formatTimeAgo(fiveMinutesAgo);
+      
+      expect(timeAgo).toContain('5 minutes ago');
+    });
+  });
+
+  describe('Storage vs Display', () => {
+    test('formatForStorage always returns UTC ISO string', () => {
+      const stored = formatForStorage(testDate);
+      expect(stored).toBe('2024-01-15T12:30:45.123Z');
+    });
+
+    test('formatForDisplay respects user timezone', () => {
+      // Test with different timezones
+      const utcDisplay = formatForDisplay(testDate, 'PPP', 'UTC');
+      const istDisplay = formatForDisplay(testDate, 'PPP', 'Asia/Kolkata');
+      
+      expect(utcDisplay).toContain('January 15th, 2024');
+      expect(istDisplay).toContain('January 15th, 2024'); // Same date, different time context
+    });
+  });
+});
+
+// Example usage patterns for developers
+export const USAGE_EXAMPLES = {
+  // When receiving date from API (always UTC)
+  parseApiDate: (isoString: string) => parseISOString(isoString),
+  
+  // When storing date to API (convert to UTC ISO)
+  prepareForApi: (date: Date) => formatForStorage(date),
+  
+  // When displaying date to user (use their timezone)
+  displayToUser: (utcDate: Date, userTimezone: string) => 
+    formatInTimeZone(utcDate, userTimezone, 'PPP'),
+  
+  // When creating database queries for a specific day
+  createDayQuery: (date: Date) => ({
+    gte: createStartOfDayUTC(date),
+    lte: createEndOfDayUTC(date),
+  }),
+  
+  // When calculating time differences
+  calculateDaysBetween: (startDate: Date, endDate: Date) => 
+    dateDifference.inDays(endDate, startDate),
+};

--- a/lib/utils/date.ts
+++ b/lib/utils/date.ts
@@ -1,115 +1,327 @@
-import dayjs from "dayjs";
-import timezone from "dayjs/plugin/timezone";
-import utc from "dayjs/plugin/utc";
+import {
+  format,
+  parseISO,
+  addDays,
+  subDays,
+  addHours,
+  addMinutes,
+  addSeconds,
+  addMilliseconds,
+  differenceInSeconds,
+  differenceInMinutes,
+  differenceInHours,
+  differenceInDays,
+  differenceInWeeks,
+  differenceInMonths,
+  differenceInYears,
+  isBefore,
+  isAfter,
+  isSameDay,
+  startOfDay,
+  endOfDay,
+  isValid,
+} from "date-fns";
+import { formatInTimeZone, utcToZonedTime, zonedTimeToUtc } from "date-fns-tz";
 
-// Extend Day.js with plugins
-dayjs.extend(utc);
-dayjs.extend(timezone);
+/**
+ * Default timezone configuration
+ * In a real app, this would come from user settings or system configuration
+ */
+export const DEFAULT_TIMEZONE = "UTC";
 
-// Function to convert epoch timestamp to human-readable date
-export const formatEpochToDate = (
-  epoch: number,
-  format: string = "DD MMM YYYY",
-  tz?: string,
-): string => {
-  // Check if epoch is in seconds (10 digits) or milliseconds (13 digits)
-  const timestamp = epoch.toString().length === 10 ? epoch * 1000 : epoch;
-
-  // Use the specified timezone, or default to the user's local timezone
-  const date = tz ? dayjs(timestamp).tz(tz) : dayjs(timestamp);
-  return date.format(format);
-};
-
-// Function to convert epoch timestamp to human-readable date
-export const formatEpochToTime = (
-  epoch: number,
-  format: string = "HH:mm:ss",
-  excludeSeconds: boolean = false,
-  tz?: string,
-): string => {
-  if (excludeSeconds) {
-    format = format.replace(/:ss/, "");
-  }
-
-  // Check if epoch is in seconds (10 digits) or milliseconds (13 digits)
-  const timestamp = epoch.toString().length === 10 ? epoch * 1000 : epoch;
-
-  // Use the specified timezone, or default to the user's local timezone
-  const date = tz ? dayjs(timestamp).tz(tz) : dayjs(timestamp);
-  return date.format(format);
-};
-
-// Function to convert date string to epoch timestamp
-export const dateToEpoch = (
-  date: string | Date | dayjs.Dayjs,
-  tz?: string,
-): number => {
-  const parsedDate = tz ? dayjs(date).tz(tz) : dayjs(date);
-  return parsedDate.valueOf(); // Returns epoch in milliseconds
-};
-
-// Function to get the user's local timezone
+/**
+ * Get the user's local timezone using Intl API
+ * This is used for display purposes only
+ */
 export const getLocalTimezone = (): string => {
   return Intl.DateTimeFormat().resolvedOptions().timeZone;
 };
 
-// Function to get the current epoch timestamp
-export const getCurrentEpoch = (tz?: string): number => {
-  return dateToEpoch(dayjs(), tz);
+/**
+ * Get current date/time in UTC (for storage)
+ * Use this instead of new Date() for consistency
+ */
+export const getCurrentDateUTC = (): Date => {
+  return new Date();
 };
 
-// Function to format date with timezone
+/**
+ * Get current epoch timestamp in milliseconds
+ * Use this instead of Date.now() when you need epoch values
+ */
+export const getCurrentEpoch = (): number => {
+  return Date.now();
+};
+
+/**
+ * Convert epoch timestamp to Date object
+ * Handles both seconds (10 digits) and milliseconds (13 digits)
+ */
+export const epochToDate = (epoch: number): Date => {
+  // Check if epoch is in seconds (10 digits) or milliseconds (13 digits)
+  const timestamp = epoch.toString().length === 10 ? epoch * 1000 : epoch;
+  return new Date(timestamp);
+};
+
+/**
+ * Convert Date object to epoch timestamp in milliseconds
+ * Use this for consistent epoch conversion
+ */
+export const dateToEpoch = (date: Date | string): number => {
+  if (typeof date === "string") {
+    const parsedDate = parseISO(date);
+    if (!isValid(parsedDate)) {
+      throw new Error(`Invalid date string: ${date}`);
+    }
+    return parsedDate.getTime();
+  }
+  return date.getTime();
+};
+
+/**
+ * Format epoch timestamp to human-readable date string
+ * Always formats in the specified timezone (defaults to user's local timezone)
+ */
+export const formatEpochToDate = (
+  epoch: number,
+  formatStr: string = "dd MMM yyyy",
+  timezone?: string,
+): string => {
+  const date = epochToDate(epoch);
+  const tz = timezone || getLocalTimezone();
+  return formatInTimeZone(date, tz, formatStr);
+};
+
+/**
+ * Format epoch timestamp to time string
+ * Always formats in the specified timezone (defaults to user's local timezone)
+ */
+export const formatEpochToTime = (
+  epoch: number,
+  formatStr: string = "HH:mm:ss",
+  excludeSeconds: boolean = false,
+  timezone?: string,
+): string => {
+  if (excludeSeconds) {
+    formatStr = formatStr.replace(/:ss/, "");
+  }
+
+  const date = epochToDate(epoch);
+  const tz = timezone || getLocalTimezone();
+  return formatInTimeZone(date, tz, formatStr);
+};
+
+/**
+ * Format date with timezone information
+ * Use this for user-facing date displays that need timezone context
+ */
 export const formatDateWithTimezone = (
   epoch: number,
-  format: string = "DD MMM YYYY HH:mm:ss z",
-  tz?: string,
+  formatStr: string = "dd MMM yyyy HH:mm:ss zzz",
+  timezone?: string,
 ): string => {
-  const timestamp = epoch.toString().length === 10 ? epoch * 1000 : epoch;
-  const date = tz ? dayjs(timestamp).tz(tz) : dayjs(timestamp);
-  return date.format(format);
+  const date = epochToDate(epoch);
+  const tz = timezone || getLocalTimezone();
+  return formatInTimeZone(date, tz, formatStr);
 };
 
-export const getNextDay = (date: Date | string | dayjs.Dayjs): Date => {
-  return dayjs(date).add(1, "day").toDate();
+/**
+ * Get the next day from a given date
+ * Returns a new Date object (UTC for storage)
+ */
+export const getNextDay = (date: Date | string): Date => {
+  const baseDate = typeof date === "string" ? parseISO(date) : date;
+  if (!isValid(baseDate)) {
+    throw new Error(`Invalid date: ${date}`);
+  }
+  return addDays(baseDate, 1);
 };
 
-export const getPreviousDay = (date: Date | string | dayjs.Dayjs): Date => {
-  return dayjs(date).subtract(1, "day").toDate();
+/**
+ * Get the previous day from a given date
+ * Returns a new Date object (UTC for storage)
+ */
+export const getPreviousDay = (date: Date | string): Date => {
+  const baseDate = typeof date === "string" ? parseISO(date) : date;
+  if (!isValid(baseDate)) {
+    throw new Error(`Invalid date: ${date}`);
+  }
+  return subDays(baseDate, 1);
 };
 
+/**
+ * Format time ago string using date-fns
+ * Use this instead of manual time calculations
+ */
 export function formatTimeAgo(date: Date): string {
-  const now = new Date();
-  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000);
+  const now = getCurrentDateUTC();
+  const diffInSeconds = differenceInSeconds(now, date);
 
   if (diffInSeconds < 60) {
     return `${diffInSeconds} seconds ago`;
   }
 
-  const diffInMinutes = Math.floor(diffInSeconds / 60);
+  const diffInMinutes = differenceInMinutes(now, date);
   if (diffInMinutes < 60) {
     return `${diffInMinutes} minute${diffInMinutes > 1 ? "s" : ""} ago`;
   }
 
-  const diffInHours = Math.floor(diffInMinutes / 60);
+  const diffInHours = differenceInHours(now, date);
   if (diffInHours < 24) {
     return `${diffInHours} hour${diffInHours > 1 ? "s" : ""} ago`;
   }
 
-  const diffInDays = Math.floor(diffInHours / 24);
+  const diffInDays = differenceInDays(now, date);
   if (diffInDays < 7) {
     return `${diffInDays} day${diffInDays > 1 ? "s" : ""} ago`;
   }
 
-  const diffInWeeks = Math.floor(diffInDays / 7);
+  const diffInWeeks = differenceInWeeks(now, date);
   if (diffInWeeks < 4) {
     return `${diffInWeeks} week${diffInWeeks > 1 ? "s" : ""} ago`;
   }
 
-  const diffInMonths = Math.floor(diffInDays / 30);
+  const diffInMonths = differenceInMonths(now, date);
   if (diffInMonths < 12) {
     return `${diffInMonths} month${diffInMonths > 1 ? "s" : ""} ago`;
   }
 
-  const diffInYears = Math.floor(diffInDays / 365);
+  const diffInYears = differenceInYears(now, date);
   return `${diffInYears} year${diffInYears > 1 ? "s" : ""} ago`;
 }
+
+/**
+ * Create start of day in UTC for database queries
+ * Use this for consistent day boundary handling in UTC
+ */
+export const createStartOfDayUTC = (date: Date | string): Date => {
+  const baseDate = typeof date === "string" ? parseISO(date) : date;
+  if (!isValid(baseDate)) {
+    throw new Error(`Invalid date: ${date}`);
+  }
+  return startOfDay(baseDate);
+};
+
+/**
+ * Create end of day in UTC for database queries
+ * Use this for consistent day boundary handling in UTC
+ */
+export const createEndOfDayUTC = (date: Date | string): Date => {
+  const baseDate = typeof date === "string" ? parseISO(date) : date;
+  if (!isValid(baseDate)) {
+    throw new Error(`Invalid date: ${date}`);
+  }
+  return endOfDay(baseDate);
+};
+
+/**
+ * Convert user timezone date to UTC for storage
+ * Use this when receiving dates from user input that are in their timezone
+ */
+export const userDateToUTC = (date: Date, userTimezone: string): Date => {
+  return zonedTimeToUtc(date, userTimezone);
+};
+
+/**
+ * Convert UTC date to user timezone for display
+ * Use this when displaying dates to users in their timezone
+ */
+export const utcToUserDate = (date: Date, userTimezone: string): Date => {
+  return utcToZonedTime(date, userTimezone);
+};
+
+/**
+ * Parse ISO string to Date object
+ * Use this instead of new Date(string) for consistent parsing
+ */
+export const parseISOString = (dateString: string): Date => {
+  const date = parseISO(dateString);
+  if (!isValid(date)) {
+    throw new Error(`Invalid ISO date string: ${dateString}`);
+  }
+  return date;
+};
+
+/**
+ * Format date for API/database storage (always UTC ISO string)
+ * Use this for consistent date serialization
+ */
+export const formatForStorage = (date: Date): string => {
+  return date.toISOString();
+};
+
+/**
+ * Format date for user display in their timezone
+ * Use this instead of toLocaleString() for consistent formatting
+ */
+export const formatForDisplay = (
+  date: Date,
+  formatStr: string = "PPP",
+  timezone?: string,
+): string => {
+  const tz = timezone || getLocalTimezone();
+  return formatInTimeZone(date, tz, formatStr);
+};
+
+/**
+ * Check if two dates are the same day (ignoring time)
+ * Use this for day-based comparisons
+ */
+export const isSameDate = (date1: Date, date2: Date): boolean => {
+  return isSameDay(date1, date2);
+};
+
+/**
+ * Compare dates (useful for sorting)
+ * Returns negative if date1 < date2, positive if date1 > date2, 0 if equal
+ */
+export const compareDates = (date1: Date, date2: Date): number => {
+  if (isBefore(date1, date2)) return -1;
+  if (isAfter(date1, date2)) return 1;
+  return 0;
+};
+
+/**
+ * Add time to a date
+ * Use these instead of manual millisecond arithmetic
+ */
+export const addTime = {
+  days: (date: Date, amount: number): Date => addDays(date, amount),
+  hours: (date: Date, amount: number): Date => addHours(date, amount),
+  minutes: (date: Date, amount: number): Date => addMinutes(date, amount),
+  seconds: (date: Date, amount: number): Date => addSeconds(date, amount),
+  milliseconds: (date: Date, amount: number): Date => addMilliseconds(date, amount),
+};
+
+/**
+ * Subtract time from a date
+ * Use these instead of manual millisecond arithmetic
+ */
+export const subtractTime = {
+  days: (date: Date, amount: number): Date => subDays(date, amount),
+  hours: (date: Date, amount: number): Date => addHours(date, -amount),
+  minutes: (date: Date, amount: number): Date => addMinutes(date, -amount),
+  seconds: (date: Date, amount: number): Date => addSeconds(date, -amount),
+  milliseconds: (date: Date, amount: number): Date => addMilliseconds(date, -amount),
+};
+
+/**
+ * Calculate differences between dates
+ * Use these instead of manual time calculations
+ */
+export const dateDifference = {
+  inSeconds: (laterDate: Date, earlierDate: Date): number => 
+    differenceInSeconds(laterDate, earlierDate),
+  inMinutes: (laterDate: Date, earlierDate: Date): number => 
+    differenceInMinutes(laterDate, earlierDate),
+  inHours: (laterDate: Date, earlierDate: Date): number => 
+    differenceInHours(laterDate, earlierDate),
+  inDays: (laterDate: Date, earlierDate: Date): number => 
+    differenceInDays(laterDate, earlierDate),
+  inWeeks: (laterDate: Date, earlierDate: Date): number => 
+    differenceInWeeks(laterDate, earlierDate),
+  inMonths: (laterDate: Date, earlierDate: Date): number => 
+    differenceInMonths(laterDate, earlierDate),
+  inYears: (laterDate: Date, earlierDate: Date): number => 
+    differenceInYears(laterDate, earlierDate),
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
-        "dayjs": "^1.11.13",
+        "date-fns-tz": "^3.2.0",
         "dotenv": "^17.2.1",
         "embla-carousel-react": "^8.6.0",
         "exceljs": "^4.4.0",
@@ -6113,6 +6113,15 @@
       "resolved": "https://registry.npmjs.org/date-fns-jalali/-/date-fns-jalali-4.1.0-0.tgz",
       "integrity": "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==",
       "license": "MIT"
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
+      }
     },
     "node_modules/dayjs": {
       "version": "1.11.13",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
-    "dayjs": "^1.11.13",
+    "date-fns-tz": "^3.2.0",
     "dotenv": "^17.2.1",
     "embla-carousel-react": "^8.6.0",
     "exceljs": "^4.4.0",


### PR DESCRIPTION
Replace all date and time handling with `date-fns` and `date-fns-tz` for consistent, timezone-aware operations.

---
<a href="https://cursor.com/background-agent?bcId=bc-db53817e-af39-4207-8c3c-f04904a0ca75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-db53817e-af39-4207-8c3c-f04904a0ca75">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

