### PR TITLE
Persist recipe table filters in local storage

### DIFF
--- a/app/(protected)/recipes/[id]/page.tsx
+++ b/app/(protected)/recipes/[id]/page.tsx
@@ -6,14 +6,13 @@ import { Button } from "@/components/ui/button";
 import api from "@/lib/api/axios";
 import type { RecipeDetailData } from "@/types";
 import { ArrowLeft, Printer } from "lucide-react";
-import { useParams, useRouter, useSearchParams } from "next/navigation";
+import { useParams, useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 
 export default function RecipeDetailPage() {
   const router = useRouter();
   const params = useParams();
-  const searchParams = useSearchParams();
   const recipeId = params.id as string;
 
   const [recipe, setRecipe] = useState<RecipeDetailData | null>(null);
@@ -87,8 +86,7 @@ export default function RecipeDetailPage() {
   };
 
   const handleBack = () => {
-    const query = searchParams?.toString();
-    router.push(query ? `/recipes?${query}` : "/recipes");
+    router.push("/recipes");
   };
 
   if (loading) {

--- a/components/recipes/recipes-table.tsx
+++ b/components/recipes/recipes-table.tsx
@@ -27,7 +27,6 @@ interface RecipesTableProps {
   itemsPerPage?: number;
   onPageChange?: (page: number) => void;
   onItemsPerPageChange?: (limit: number) => void;
-  listQuery?: string;
 }
 
 export function RecipesTable({
@@ -43,7 +42,6 @@ export function RecipesTable({
   itemsPerPage,
   onPageChange,
   onItemsPerPageChange,
-  listQuery,
 }: RecipesTableProps) {
   // Use server-side pagination - no local slicing needed
   const displayRecipes = recipes;
@@ -87,7 +85,7 @@ export function RecipesTable({
               <TableRow key={recipe.id}>
                 <TableCell className="py-4 px-6 font-medium text-foreground">
                   <Link
-                    href={`/recipes/${recipe.id}${listQuery ? `?${listQuery}` : ""}`}
+                    href={`/recipes/${recipe.id}`}
                     className="hover:text-primary hover:underline cursor-pointer transition-colors"
                   >
                     {recipe.name}


### PR DESCRIPTION
Store recipe table page filters in localStorage to preserve state across sessions and remove URL query parameter syncing.

This change moves the persistence mechanism for the recipe list filters from URL query parameters to `localStorage`. This allows the filter state (search, category, pagination, filter panel visibility) to be maintained when navigating away and back, or refreshing the page, without cluttering the URL. The state is initialized from `localStorage` on mount, updated on changes, and cleared when the "Clear" action is used. Consequently, the `RecipesTable` no longer accepts a `listQuery` prop, and the `RecipeDetailPage`'s back button navigates directly to `/recipes`.

---
<a href="https://cursor.com/background-agent?bcId=bc-92f785a5-95c7-4df8-b3d6-096eb78b220d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92f785a5-95c7-4df8-b3d6-096eb78b220d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

