### PR TITLE
Refactor quantity inputs into reusable components

### DIFF
--- a/app/api/recipes/route.ts
+++ b/app/api/recipes/route.ts
@@ -280,9 +280,12 @@ export async function POST(request: NextRequest) {
       });
     });
 
-    return recipe;
+    return NextResponse.json(recipe, { status: 201 });
   } catch (error) {
     console.error("Create recipe error:", error);
-    throw error;
+    return NextResponse.json(
+      { error: "Failed to create recipe" },
+      { status: 500 },
+    );
   }
 }

--- a/components/dialogs/add-edit-menu-component-dialog.tsx
+++ b/components/dialogs/add-edit-menu-component-dialog.tsx
@@ -9,6 +9,9 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { FormikValueUnitInput } from "@/components/ui/value-unit-input";
+import { UNIT_OPTIONS, getWeightUnits } from "@/lib/constants/units";
+import type { UnitOption } from "@/types";
 import type { KitchenPersonType } from "@/types/kitchens";
 import {
   MealType,
@@ -42,6 +45,11 @@ const mealTypesObj = {
 
 const quantityUnits = ["g", "kg", "pcs"] as const;
 const weightUnits = ["g", "kg"] as const;
+
+const quantityUnitOptions: UnitOption[] = UNIT_OPTIONS.filter((o) =>
+  (quantityUnits as readonly string[]).includes(o.value),
+);
+const weightUnitOptions: UnitOption[] = getWeightUnits();
 
 const createEmptyAverage = (): MenuComponentAverageInput => ({
   personTypeId: "",
@@ -392,94 +400,50 @@ export function AddEditMenuComponentDialog({
                             <Label htmlFor={`averages.${index}.quantity`}>
                               Quantity
                             </Label>
-                            <Field
-                              as={Input}
+                            <FormikValueUnitInput
                               id={`averages.${index}.quantity`}
-                              name={`averages.${index}.quantity`}
-                              type="number"
+                              quantityName={`averages.${index}.quantity`}
+                              unitName={`averages.${index}.unit`}
+                              unitOptions={quantityUnitOptions}
                               min={0}
                               step={0.0001}
+                              onUnitChange={(value) => {
+                                setFieldTouched(
+                                  `averages.${index}.unit`,
+                                  true,
+                                  false,
+                                );
+                                if (value !== "pcs") {
+                                  setFieldValue(
+                                    `averages.${index}.weightPerPiece`,
+                                    null,
+                                  );
+                                  setFieldValue(
+                                    `averages.${index}.weightPerPieceUnit`,
+                                    null,
+                                  );
+                                } else if (
+                                  !values.averages[index].weightPerPieceUnit
+                                ) {
+                                  setFieldValue(
+                                    `averages.${index}.weightPerPieceUnit`,
+                                    "g",
+                                  );
+                                }
+                              }}
                             />
                             <ErrorMessage
                               name={`averages.${index}.quantity`}
                               component="div"
                               className="text-destructive text-xs mt-1"
                             />
-                          </div>
-                          <div>
-                            <Label htmlFor={`averages.${index}.unit`}>
-                              Unit
-                            </Label>
-                            <Field name={`averages.${index}.unit`}>
-                              {({ field }: { field: any }) => (
-                                <Select
-                                  value={field.value}
-                                  onValueChange={(value) => {
-                                    setFieldTouched(field.name, true, false);
-                                    field.onChange({
-                                      target: { name: field.name, value },
-                                    });
-
-                                    if (value !== "pcs") {
-                                      setFieldValue(
-                                        `averages.${index}.weightPerPiece`,
-                                        null,
-                                      );
-                                      setFieldValue(
-                                        `averages.${index}.weightPerPieceUnit`,
-                                        null,
-                                      );
-                                    } else if (
-                                      !values.averages[index].weightPerPieceUnit
-                                    ) {
-                                      setFieldValue(
-                                        `averages.${index}.weightPerPieceUnit`,
-                                        "g",
-                                      );
-                                    }
-                                  }}
-                                >
-                                  <SelectTrigger className="w-full">
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    {quantityUnits.map((unit) => (
-                                      <SelectItem key={unit} value={unit}>
-                                        {unit}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                              )}
-                            </Field>
                             <ErrorMessage
                               name={`averages.${index}.unit`}
                               component="div"
                               className="text-destructive text-xs mt-1"
                             />
                           </div>
-                          {usesPieces ? (
-                            <div>
-                              <Label
-                                htmlFor={`averages.${index}.weightPerPiece`}
-                              >
-                                Weight per piece
-                              </Label>
-                              <Field
-                                as={Input}
-                                id={`averages.${index}.weightPerPiece`}
-                                name={`averages.${index}.weightPerPiece`}
-                                type="number"
-                                min={0}
-                                step={0.0001}
-                              />
-                              <ErrorMessage
-                                name={`averages.${index}.weightPerPiece`}
-                                component="div"
-                                className="text-destructive text-xs mt-1"
-                              />
-                            </div>
-                          ) : (
+                          {!usesPieces && (
                             <div className="text-xs text-muted-foreground self-end pb-2">
                               Weight per piece is only needed for piece-based
                               averages.
@@ -490,36 +454,30 @@ export function AddEditMenuComponentDialog({
                         {usesPieces && (
                           <div className="mt-4 max-w-xs">
                             <Label
-                              htmlFor={`averages.${index}.weightPerPieceUnit`}
+                              htmlFor={`averages.${index}.weightPerPiece`}
                             >
-                              Weight unit
+                              Weight per piece
                             </Label>
-                            <Field
-                              name={`averages.${index}.weightPerPieceUnit`}
-                            >
-                              {({ field }: { field: any }) => (
-                                <Select
-                                  value={field.value || "g"}
-                                  onValueChange={(value) => {
-                                    setFieldTouched(field.name, true, false);
-                                    field.onChange({
-                                      target: { name: field.name, value },
-                                    });
-                                  }}
-                                >
-                                  <SelectTrigger className="w-full">
-                                    <SelectValue />
-                                  </SelectTrigger>
-                                  <SelectContent>
-                                    {weightUnits.map((unit) => (
-                                      <SelectItem key={unit} value={unit}>
-                                        {unit}
-                                      </SelectItem>
-                                    ))}
-                                  </SelectContent>
-                                </Select>
-                              )}
-                            </Field>
+                            <FormikValueUnitInput
+                              id={`averages.${index}.weightPerPiece`}
+                              quantityName={`averages.${index}.weightPerPiece`}
+                              unitName={`averages.${index}.weightPerPieceUnit`}
+                              unitOptions={weightUnitOptions}
+                              min={0}
+                              step={0.0001}
+                              onUnitChange={() =>
+                                setFieldTouched(
+                                  `averages.${index}.weightPerPieceUnit`,
+                                  true,
+                                  false,
+                                )
+                              }
+                            />
+                            <ErrorMessage
+                              name={`averages.${index}.weightPerPiece`}
+                              component="div"
+                              className="text-destructive text-xs mt-1"
+                            />
                             <ErrorMessage
                               name={`averages.${index}.weightPerPieceUnit`}
                               component="div"

--- a/components/dialogs/add-meal-dialog.tsx
+++ b/components/dialogs/add-meal-dialog.tsx
@@ -25,6 +25,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { FormikValueUnitInput } from "@/components/ui/value-unit-input";
+import { QuantityWithPieceInput } from "@/components/ui/quantity-with-piece-input";
 import { useTranslations } from "@/hooks/use-translations";
 import api from "@/lib/api/axios";
 import { fetchMenuComponents } from "@/lib/api/menu-components";
@@ -1554,94 +1555,35 @@ export function AddMealDialog({
 
                             {/* Prepared Quantity */}
                             <div className="col-span-12 @sm:col-span-6 @xl:col-span-4 @5xl:col-span-2">
-                              <Label
-                                htmlFor="preparedQuantity"
-                                className="mb-1 block text-xs font-medium text-foreground"
-                              >
-                                {t("recipes.preparedQuantity")}{" "}
-                                {values.followRecipe ? "(per ghan)" : ""}
-                              </Label>
-                              <FormikValueUnitInput
+                              <QuantityWithPieceInput
                                 id="preparedQuantity"
+                                label={`${t("recipes.preparedQuantity")}${values.followRecipe ? " (per ghan)" : ""}`}
                                 quantityName="preparedQuantity"
                                 unitName="preparedQuantityUnit"
+                                pieceQuantityName="quantityPerPiece"
+                                pieceUnit={values.servingQuantityUnit}
                                 min={0}
                                 step={0.0001}
                                 placeholder={t("recipes.preparedQuantity")}
-                                className="h-9"
-                              />
-                              <ErrorMessage
-                                name="preparedQuantity"
-                                component="p"
-                                className="text-destructive text-xs mt-1 flex items-center gap-1"
-                              />
-                              <ErrorMessage
-                                name="preparedQuantityUnit"
-                                component="p"
-                                className="text-destructive text-xs mt-1 flex items-center gap-1"
+                                inputClassName="h-9"
+                                labelClassName="text-xs"
                               />
                             </div>
                             <div className="col-span-12 @sm:col-span-6 @xl:col-span-4 @5xl:col-span-2">
-                              <Label
-                                htmlFor="servingQuantity"
-                                className="mb-1 block text-xs font-medium text-foreground"
-                              >
-                                {t("recipes.servingQuantity")}
-                              </Label>
-                              <FormikValueUnitInput
+                              <QuantityWithPieceInput
                                 id="servingQuantity"
+                                label={t("recipes.servingQuantity")}
                                 quantityName="servingQuantity"
                                 unitName="servingQuantityUnit"
+                                pieceQuantityName="quantityPerPiece"
+                                pieceUnit={values.preparedQuantityUnit}
                                 min={0}
                                 step={0.0001}
                                 placeholder={t("recipes.servingQuantity")}
-                                className="h-9"
-                              />
-                              <ErrorMessage
-                                name="servingQuantity"
-                                component="p"
-                                className="text-destructive text-xs mt-1 flex items-center gap-1"
-                              />
-                              <ErrorMessage
-                                name="servingQuantityUnit"
-                                component="p"
-                                className="text-destructive text-xs mt-1 flex items-center gap-1"
+                                inputClassName="h-9"
+                                labelClassName="text-xs"
                               />
                             </div>
-                            {/* Quantity Per Piece (only if exactly one of the units is 'pcs') */}
-                            {(values.servingQuantityUnit === "pcs") !==
-                              (values.preparedQuantityUnit === "pcs") && (
-                              <div className="col-span-12 @sm:col-span-6 @xl:col-span-4 @5xl:col-span-2">
-                                <Label
-                                  htmlFor="quantityPerPiece"
-                                  className="mb-1 block text-xs font-medium text-foreground"
-                                >
-                                  {t("recipes.quantityPerPiece")}
-                                </Label>
-                                <div className="flex h-9 items-center rounded-md border border-input bg-background focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
-                                  <Field
-                                    id="quantityPerPiece"
-                                    name="quantityPerPiece"
-                                    type="number"
-                                    min={0}
-                                    step={0.0001}
-                                    placeholder="Quantity per piece"
-                                    className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                                  />
-                                  <div className="w-px self-stretch bg-input my-1" />
-                                  <span className="shrink-0 px-2 text-sm font-medium text-foreground">
-                                    {values.servingQuantityUnit === "pcs"
-                                      ? values.preparedQuantityUnit
-                                      : values.servingQuantityUnit}
-                                  </span>
-                                </div>
-                                <ErrorMessage
-                                  name="quantityPerPiece"
-                                  component="p"
-                                  className="text-destructive text-xs mt-1 flex items-center gap-1"
-                                />
-                              </div>
-                            )}
                           </div>
 
                           {/* Quantity calculations */}

--- a/components/dialogs/add-meal-dialog.tsx
+++ b/components/dialogs/add-meal-dialog.tsx
@@ -1608,9 +1608,9 @@ export function AddMealDialog({
                                 className="text-destructive text-xs mt-1 flex items-center gap-1"
                               />
                             </div>
-                            {/* Quantity Per Piece (only if servingQuantityUnit is 'pcs') */}
-                            {(values.servingQuantityUnit === "pcs" ||
-                              values.preparedQuantityUnit === "pcs") && (
+                            {/* Quantity Per Piece (only if exactly one of the units is 'pcs') */}
+                            {(values.servingQuantityUnit === "pcs") !==
+                              (values.preparedQuantityUnit === "pcs") && (
                               <div className="col-span-12 @sm:col-span-6 @xl:col-span-4 @5xl:col-span-2">
                                 <Label
                                   htmlFor="quantityPerPiece"

--- a/components/dialogs/add-meal-dialog.tsx
+++ b/components/dialogs/add-meal-dialog.tsx
@@ -1618,16 +1618,23 @@ export function AddMealDialog({
                                 >
                                   {t("recipes.quantityPerPiece")}
                                 </Label>
-                                <Field
-                                  as={Input}
-                                  id="quantityPerPiece"
-                                  name="quantityPerPiece"
-                                  type="number"
-                                  min={0}
-                                  step={0.0001}
-                                  placeholder="Quantity per piece"
-                                  className="h-9 border-border focus:border-primary focus:ring-primary/20"
-                                />
+                                <div className="flex h-9 items-center rounded-md border border-input bg-background focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
+                                  <Field
+                                    id="quantityPerPiece"
+                                    name="quantityPerPiece"
+                                    type="number"
+                                    min={0}
+                                    step={0.0001}
+                                    placeholder="Quantity per piece"
+                                    className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                                  />
+                                  <div className="w-px self-stretch bg-input my-1" />
+                                  <span className="shrink-0 px-2 text-sm font-medium text-foreground">
+                                    {values.servingQuantityUnit === "pcs"
+                                      ? values.preparedQuantityUnit
+                                      : values.servingQuantityUnit}
+                                  </span>
+                                </div>
                                 <ErrorMessage
                                   name="quantityPerPiece"
                                   component="p"

--- a/components/dialogs/add-meal-dialog.tsx
+++ b/components/dialogs/add-meal-dialog.tsx
@@ -24,6 +24,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { FormikValueUnitInput } from "@/components/ui/value-unit-input";
 import { useTranslations } from "@/hooks/use-translations";
 import api from "@/lib/api/axios";
 import { fetchMenuComponents } from "@/lib/api/menu-components";
@@ -1560,55 +1561,20 @@ export function AddMealDialog({
                                 {t("recipes.preparedQuantity")}{" "}
                                 {values.followRecipe ? "(per ghan)" : ""}
                               </Label>
-                              <Field
-                                as={Input}
+                              <FormikValueUnitInput
                                 id="preparedQuantity"
-                                name="preparedQuantity"
-                                type="number"
+                                quantityName="preparedQuantity"
+                                unitName="preparedQuantityUnit"
                                 min={0}
                                 step={0.0001}
                                 placeholder={t("recipes.preparedQuantity")}
-                                className="h-9 border-border focus:border-primary focus:ring-primary/20"
+                                className="h-9"
                               />
                               <ErrorMessage
                                 name="preparedQuantity"
                                 component="p"
                                 className="text-destructive text-xs mt-1 flex items-center gap-1"
                               />
-                            </div>
-                            <div className="col-span-12 @sm:col-span-6 @xl:col-span-4 @5xl:col-span-2">
-                              <Label
-                                htmlFor="preparedQuantityUnit"
-                                className="mb-1 block text-xs font-medium text-foreground"
-                              >
-                                {t("recipes.preparedQuantityUnit")}
-                              </Label>
-                              <Field name="preparedQuantityUnit">
-                                {({ field }: { field: any }) => (
-                                  <Select
-                                    value={field.value}
-                                    onValueChange={(value) =>
-                                      field.onChange({
-                                        target: { name: field.name, value },
-                                      })
-                                    }
-                                  >
-                                    <SelectTrigger className="h-9 text-sm">
-                                      <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent searchable>
-                                      {UNIT_OPTIONS.map((option) => (
-                                        <SelectItem
-                                          key={option.value}
-                                          value={option.value}
-                                        >
-                                          {option.label}
-                                        </SelectItem>
-                                      ))}
-                                    </SelectContent>
-                                  </Select>
-                                )}
-                              </Field>
                               <ErrorMessage
                                 name="preparedQuantityUnit"
                                 component="p"
@@ -1622,55 +1588,20 @@ export function AddMealDialog({
                               >
                                 {t("recipes.servingQuantity")}
                               </Label>
-                              <Field
-                                as={Input}
+                              <FormikValueUnitInput
                                 id="servingQuantity"
-                                name="servingQuantity"
-                                type="number"
+                                quantityName="servingQuantity"
+                                unitName="servingQuantityUnit"
                                 min={0}
                                 step={0.0001}
-                                placeholder="Serving quantity"
-                                className="h-9 border-border focus:border-primary focus:ring-primary/20"
+                                placeholder={t("recipes.servingQuantity")}
+                                className="h-9"
                               />
                               <ErrorMessage
                                 name="servingQuantity"
                                 component="p"
                                 className="text-destructive text-xs mt-1 flex items-center gap-1"
                               />
-                            </div>
-                            <div className="col-span-12 @sm:col-span-6 @xl:col-span-4 @5xl:col-span-2">
-                              <Label
-                                htmlFor="servingQuantityUnit"
-                                className="mb-1 block text-xs font-medium text-foreground"
-                              >
-                                {t("recipes.servingQuantityUnit")}
-                              </Label>
-                              <Field name="servingQuantityUnit">
-                                {({ field }: { field: any }) => (
-                                  <Select
-                                    value={field.value}
-                                    onValueChange={(value) =>
-                                      field.onChange({
-                                        target: { name: field.name, value },
-                                      })
-                                    }
-                                  >
-                                    <SelectTrigger className="h-9 text-sm">
-                                      <SelectValue />
-                                    </SelectTrigger>
-                                    <SelectContent searchable>
-                                      {UNIT_OPTIONS.map((option) => (
-                                        <SelectItem
-                                          key={option.value}
-                                          value={option.value}
-                                        >
-                                          {option.label}
-                                        </SelectItem>
-                                      ))}
-                                    </SelectContent>
-                                  </Select>
-                                )}
-                              </Field>
                               <ErrorMessage
                                 name="servingQuantityUnit"
                                 component="p"

--- a/components/dialogs/add-recipe-dialog.tsx
+++ b/components/dialogs/add-recipe-dialog.tsx
@@ -744,7 +744,7 @@ export function AddRecipeDialog({
 
                   {/* Quantity calculations */}
                   <div className="p-2 border border-border rounded-lg bg-accent">
-                    <p className="text-sm text-foreground/70">
+                    <div className="text-sm text-foreground/70">
                       {((
                         calculatedQuantities = getCalculatedQuantities({
                           preparedQuantity: values.preparedQuantity,
@@ -773,7 +773,7 @@ export function AddRecipeDialog({
                           </div>
                         </div>
                       ))()}
-                    </p>
+                    </div>
                   </div>
                 </CardContent>
               </Card>

--- a/components/dialogs/add-recipe-dialog.tsx
+++ b/components/dialogs/add-recipe-dialog.tsx
@@ -14,6 +14,7 @@ import { IngredientsInput } from "@/components/ui/ingredients-input";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { FormikValueUnitInput } from "@/components/ui/value-unit-input";
+import { QuantityWithPieceInput } from "@/components/ui/quantity-with-piece-input";
 import { useTranslations } from "@/hooks/use-translations";
 import {
   DEFAULT_UNIT,
@@ -711,94 +712,34 @@ export function AddRecipeDialog({
                   </CardDescription>
                 </CardHeader>
                 <CardContent className="space-y-4">
-                  {/* Prepared Quantity */}
+                  {/* Prepared & Serving Quantity */}
                   <div className="@container grid grid-cols-12 gap-4">
                     <div className="col-span-12 @sm:col-span-6 @xl:col-span-3">
-                      <Label
-                        htmlFor="preparedQuantity"
-                        className="text-sm font-medium text-foreground mb-2 block"
-                      >
-                        {t("recipes.preparedQuantity")}
-                      </Label>
-                      <FormikValueUnitInput
+                      <QuantityWithPieceInput
                         id="preparedQuantity"
+                        label={t("recipes.preparedQuantity")}
                         quantityName="preparedQuantity"
                         unitName="preparedQuantityUnit"
+                        pieceQuantityName="quantityPerPiece"
+                        pieceUnit={values.servingQuantityUnit}
                         min={0}
                         step={0.0001}
                         placeholder={t("recipes.preparedQuantity")}
                       />
-                      <ErrorMessage
-                        name="preparedQuantity"
-                        component="p"
-                        className="text-destructive text-xs mt-1 flex items-center gap-1"
-                      />
-                      <ErrorMessage
-                        name="preparedQuantityUnit"
-                        component="p"
-                        className="text-destructive text-xs mt-1 flex items-center gap-1"
-                      />
                     </div>
                     <div className="col-span-12 @sm:col-span-6 @xl:col-span-3">
-                      <Label
-                        htmlFor="servingQuantity"
-                        className="text-sm font-medium text-foreground mb-2 block"
-                      >
-                        {t("recipes.servingQuantity")}
-                      </Label>
-                      <FormikValueUnitInput
+                      <QuantityWithPieceInput
                         id="servingQuantity"
+                        label={t("recipes.servingQuantity")}
                         quantityName="servingQuantity"
                         unitName="servingQuantityUnit"
+                        pieceQuantityName="quantityPerPiece"
+                        pieceUnit={values.preparedQuantityUnit}
                         min={0}
                         step={0.0001}
                         placeholder={t("recipes.servingQuantity")}
                       />
-                      <ErrorMessage
-                        name="servingQuantity"
-                        component="p"
-                        className="text-destructive text-xs mt-1 flex items-center gap-1"
-                      />
-                      <ErrorMessage
-                        name="servingQuantityUnit"
-                        component="p"
-                        className="text-destructive text-xs mt-1 flex items-center gap-1"
-                      />
                     </div>
-                    {/* Quantity Per Piece (only if exactly one of the units is 'pcs') */}
-                    {(values.servingQuantityUnit === "pcs") !==
-                      (values.preparedQuantityUnit === "pcs") && (
-                      <div className="col-span-12 @sm:col-span-6 @xl:col-span-3 @3xl:col-span-2">
-                        <Label
-                          htmlFor="quantityPerPiece"
-                          className="text-sm font-medium text-foreground mb-2 block"
-                        >
-                          {t("recipes.quantityPerPiece")}
-                        </Label>
-                        <div className="flex h-10 items-center rounded-md border border-input bg-background focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
-                          <Field
-                            id="quantityPerPiece"
-                            name="quantityPerPiece"
-                            type="number"
-                            min={0}
-                            step={0.0001}
-                            placeholder="Quantity per piece"
-                            className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-                          />
-                          <div className="w-px self-stretch bg-input my-1" />
-                          <span className="shrink-0 px-2 text-sm font-medium text-foreground">
-                            {values.servingQuantityUnit === "pcs"
-                              ? values.preparedQuantityUnit
-                              : values.servingQuantityUnit}
-                          </span>
-                        </div>
-                        <ErrorMessage
-                          name="quantityPerPiece"
-                          component="p"
-                          className="text-destructive text-xs mt-1 flex items-center gap-1"
-                        />
-                      </div>
-                    )}
                   </div>
 
                   {/* Quantity calculations */}

--- a/components/dialogs/add-recipe-dialog.tsx
+++ b/components/dialogs/add-recipe-dialog.tsx
@@ -457,7 +457,8 @@ export function AddRecipeDialog({
         ? normalizeUnit(trimmedValues.servingQuantityUnit)
         : null,
       quantityPerPiece:
-        trimmedValues.servingQuantityUnit === "pcs"
+        (trimmedValues.servingQuantityUnit === "pcs") !==
+        (trimmedValues.preparedQuantityUnit === "pcs")
           ? trimmedValues.quantityPerPiece
           : null,
     };
@@ -764,8 +765,9 @@ export function AddRecipeDialog({
                         className="text-destructive text-xs mt-1 flex items-center gap-1"
                       />
                     </div>
-                    {/* Quantity Per Piece (only if servingQuantityUnit is 'pcs') */}
-                    {values.servingQuantityUnit === "pcs" && (
+                    {/* Quantity Per Piece (only if exactly one of the units is 'pcs') */}
+                    {(values.servingQuantityUnit === "pcs") !==
+                      (values.preparedQuantityUnit === "pcs") && (
                       <div className="col-span-12 @sm:col-span-6 @xl:col-span-3 @3xl:col-span-2">
                         <Label
                           htmlFor="quantityPerPiece"
@@ -785,7 +787,9 @@ export function AddRecipeDialog({
                           />
                           <div className="w-px self-stretch bg-input my-1" />
                           <span className="shrink-0 px-2 text-sm font-medium text-foreground">
-                            {values.preparedQuantityUnit}
+                            {values.servingQuantityUnit === "pcs"
+                              ? values.preparedQuantityUnit
+                              : values.servingQuantityUnit}
                           </span>
                         </div>
                         <ErrorMessage

--- a/components/dialogs/add-recipe-dialog.tsx
+++ b/components/dialogs/add-recipe-dialog.tsx
@@ -773,16 +773,21 @@ export function AddRecipeDialog({
                         >
                           {t("recipes.quantityPerPiece")}
                         </Label>
-                        <Field
-                          as={Input}
-                          id="quantityPerPiece"
-                          name="quantityPerPiece"
-                          type="number"
-                          min={0}
-                          step={0.0001}
-                          placeholder="Quantity per piece"
-                          className="border-border focus:border-primary focus:ring-primary/20"
-                        />
+                        <div className="flex h-10 items-center rounded-md border border-input bg-background focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2">
+                          <Field
+                            id="quantityPerPiece"
+                            name="quantityPerPiece"
+                            type="number"
+                            min={0}
+                            step={0.0001}
+                            placeholder="Quantity per piece"
+                            className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+                          />
+                          <div className="w-px self-stretch bg-input my-1" />
+                          <span className="shrink-0 px-2 text-sm font-medium text-foreground">
+                            {values.preparedQuantityUnit}
+                          </span>
+                        </div>
                         <ErrorMessage
                           name="quantityPerPiece"
                           component="p"

--- a/components/dialogs/add-recipe-dialog.tsx
+++ b/components/dialogs/add-recipe-dialog.tsx
@@ -13,6 +13,7 @@ import {
 import { IngredientsInput } from "@/components/ui/ingredients-input";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { FormikValueUnitInput } from "@/components/ui/value-unit-input";
 import { useTranslations } from "@/hooks/use-translations";
 import {
   DEFAULT_UNIT,
@@ -711,124 +712,52 @@ export function AddRecipeDialog({
                 <CardContent className="space-y-4">
                   {/* Prepared Quantity */}
                   <div className="@container grid grid-cols-12 gap-4">
-                    <div className="col-span-12 @sm:col-span-6 @xl:col-span-3 @3xl:col-span-2">
+                    <div className="col-span-12 @sm:col-span-6 @xl:col-span-3">
                       <Label
                         htmlFor="preparedQuantity"
                         className="text-sm font-medium text-foreground mb-2 block"
                       >
                         {t("recipes.preparedQuantity")}
                       </Label>
-                      <Field
-                        as={Input}
+                      <FormikValueUnitInput
                         id="preparedQuantity"
-                        name="preparedQuantity"
-                        type="number"
+                        quantityName="preparedQuantity"
+                        unitName="preparedQuantityUnit"
                         min={0}
                         step={0.0001}
                         placeholder={t("recipes.preparedQuantity")}
-                        className="border-border focus:border-primary focus:ring-primary/20"
                       />
                       <ErrorMessage
                         name="preparedQuantity"
                         component="p"
                         className="text-destructive text-xs mt-1 flex items-center gap-1"
                       />
-                    </div>
-                    <div className="col-span-12 @sm:col-span-6 @xl:col-span-3">
-                      <Label
-                        htmlFor="preparedQuantityUnit"
-                        className="text-sm font-medium text-foreground mb-2 block"
-                      >
-                        {t("recipes.preparedQuantityUnit")}
-                      </Label>
-                      <Field name="preparedQuantityUnit">
-                        {({ field }: { field: any }) => (
-                          <Select
-                            value={field.value}
-                            onValueChange={(value) =>
-                              field.onChange({
-                                target: { name: field.name, value },
-                              })
-                            }
-                          >
-                            <SelectTrigger className="text-sm">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent searchable>
-                              {UNIT_OPTIONS.map((option) => (
-                                <SelectItem
-                                  key={option.value}
-                                  value={option.value}
-                                >
-                                  {option.label}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        )}
-                      </Field>
                       <ErrorMessage
                         name="preparedQuantityUnit"
                         component="p"
                         className="text-destructive text-xs mt-1 flex items-center gap-1"
                       />
                     </div>
-                    <div className="col-span-12 @sm:col-span-6 @xl:col-span-3 @3xl:col-span-2">
+                    <div className="col-span-12 @sm:col-span-6 @xl:col-span-3">
                       <Label
                         htmlFor="servingQuantity"
                         className="text-sm font-medium text-foreground mb-2 block"
                       >
                         {t("recipes.servingQuantity")}
                       </Label>
-                      <Field
-                        as={Input}
+                      <FormikValueUnitInput
                         id="servingQuantity"
-                        name="servingQuantity"
-                        type="number"
+                        quantityName="servingQuantity"
+                        unitName="servingQuantityUnit"
                         min={0}
                         step={0.0001}
-                        placeholder="Serving quantity"
-                        className="border-border focus:border-primary focus:ring-primary/20"
+                        placeholder={t("recipes.servingQuantity")}
                       />
                       <ErrorMessage
                         name="servingQuantity"
                         component="p"
                         className="text-destructive text-xs mt-1 flex items-center gap-1"
                       />
-                    </div>
-                    <div className="col-span-12 @sm:col-span-6 @xl:col-span-3">
-                      <Label
-                        htmlFor="servingQuantityUnit"
-                        className="text-sm font-medium text-foreground mb-2 block"
-                      >
-                        {t("recipes.servingQuantityUnit")}
-                      </Label>
-                      <Field name="servingQuantityUnit">
-                        {({ field }: { field: any }) => (
-                          <Select
-                            value={field.value}
-                            onValueChange={(value) =>
-                              field.onChange({
-                                target: { name: field.name, value },
-                              })
-                            }
-                          >
-                            <SelectTrigger className="text-sm">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent searchable>
-                              {UNIT_OPTIONS.map((option) => (
-                                <SelectItem
-                                  key={option.value}
-                                  value={option.value}
-                                >
-                                  {option.label}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        )}
-                      </Field>
                       <ErrorMessage
                         name="servingQuantityUnit"
                         component="p"

--- a/components/ui/ingredients-input.tsx
+++ b/components/ui/ingredients-input.tsx
@@ -18,13 +18,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+import { FormikValueUnitInput } from "@/components/ui/value-unit-input";
 import { DEFAULT_UNIT, UNIT_OPTIONS } from "@/lib/constants/units";
 import type { UnitValue } from "@/types";
 import { useRef } from "react";
@@ -154,55 +148,27 @@ function Ingredient({
           />
         </div>
 
-        <div className="sm:col-span-3">
+        <div className="sm:col-span-6">
           <Label className="text-xs font-medium text-muted-foreground mb-1 block">
             Quantity *
           </Label>
-          <Field
-            as={Input}
-            name={`${name}[${groupIndex}].ingredients[${ingredientIndex}].quantity`}
+          <FormikValueUnitInput
+            quantityName={`${name}[${groupIndex}].ingredients[${ingredientIndex}].quantity`}
+            unitName={`${name}[${groupIndex}].ingredients[${ingredientIndex}].unit`}
             placeholder="Amount"
-            type="number"
             min={0}
             step={0.0001}
-            className="text-sm"
           />
           <ErrorMessage
             name={`${name}[${groupIndex}].ingredients[${ingredientIndex}].quantity`}
             component="p"
             className="text-destructive text-xs mt-1"
           />
-        </div>
-
-        <div className="sm:col-span-3">
-          <Label className="text-xs font-medium text-muted-foreground mb-1 block">
-            Unit *
-          </Label>
-          <Field
+          <ErrorMessage
             name={`${name}[${groupIndex}].ingredients[${ingredientIndex}].unit`}
-          >
-            {({ field }: { field: any }) => (
-              <Select
-                value={field.value}
-                onValueChange={(value) =>
-                  field.onChange({
-                    target: { name: field.name, value },
-                  })
-                }
-              >
-                <SelectTrigger className="text-sm">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent searchable>
-                  {UNIT_OPTIONS.map((option) => (
-                    <SelectItem key={option.value} value={option.value}>
-                      {option.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            )}
-          </Field>
+            component="p"
+            className="text-destructive text-xs mt-1"
+          />
         </div>
 
         <div className="sm:col-span-2">

--- a/components/ui/quantity-with-piece-input.tsx
+++ b/components/ui/quantity-with-piece-input.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { ErrorMessage, Field, useFormikContext } from "formik";
+import { CornerDownRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
+import { FormikValueUnitInput } from "@/components/ui/value-unit-input";
+import type { UnitOption } from "@/types";
+
+interface QuantityWithPieceInputProps {
+  label: string;
+  id?: string;
+  quantityName: string;
+  unitName: string;
+  /** Formik field name for the shared quantityPerPiece value */
+  pieceQuantityName: string;
+  /** The unit to display read-only next to the per-piece input (the other quantity's unit) */
+  pieceUnit: string;
+  unitOptions?: UnitOption[];
+  placeholder?: string;
+  min?: number;
+  step?: number;
+  /** className forwarded to the main ValueUnitInput container (e.g. "h-9") */
+  inputClassName?: string;
+  labelClassName?: string;
+  pieceLabel?: string;
+}
+
+export function QuantityWithPieceInput({
+  label,
+  id,
+  quantityName,
+  unitName,
+  pieceQuantityName,
+  pieceUnit,
+  unitOptions,
+  placeholder,
+  min,
+  step,
+  inputClassName,
+  labelClassName,
+  pieceLabel = "Per piece",
+}: QuantityWithPieceInputProps) {
+  const { getFieldProps } = useFormikContext<any>();
+  const isPcs = getFieldProps(unitName).value === "pcs";
+
+  return (
+    <div>
+      <Label
+        htmlFor={id}
+        className={cn(
+          "mb-1 block text-sm font-medium text-foreground",
+          labelClassName,
+        )}
+      >
+        {label}
+      </Label>
+
+      <FormikValueUnitInput
+        id={id}
+        quantityName={quantityName}
+        unitName={unitName}
+        unitOptions={unitOptions}
+        placeholder={placeholder}
+        min={min}
+        step={step}
+        className={inputClassName}
+      />
+      <ErrorMessage
+        name={quantityName}
+        component="p"
+        className="mt-1 flex items-center gap-1 text-xs text-destructive"
+      />
+      <ErrorMessage
+        name={unitName}
+        component="p"
+        className="mt-1 flex items-center gap-1 text-xs text-destructive"
+      />
+
+      {isPcs && (
+        <div className="mt-2 flex items-start gap-1.5 pl-1">
+          <CornerDownRight
+            className="mt-1.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
+            aria-hidden
+          />
+          <div className="flex-1">
+            <span className="mb-1 block text-xs text-muted-foreground">
+              {pieceLabel}
+            </span>
+            <div
+              className={cn(
+                "flex items-center rounded-md border border-input bg-background",
+                "ring-offset-background focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+                inputClassName ?? "h-10",
+              )}
+            >
+              <Field
+                name={pieceQuantityName}
+                type="number"
+                min={0}
+                step={0.0001}
+                placeholder="0"
+                className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+              />
+              <div className="my-1 w-px self-stretch bg-input" />
+              <span className="shrink-0 px-2 text-sm font-medium text-foreground">
+                {pieceUnit}
+              </span>
+            </div>
+            <ErrorMessage
+              name={pieceQuantityName}
+              component="p"
+              className="mt-1 text-xs text-destructive"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/ui/quantity-with-piece-input.tsx
+++ b/components/ui/quantity-with-piece-input.tsx
@@ -43,10 +43,11 @@ export function QuantityWithPieceInput({
   pieceLabel = "Per piece",
 }: QuantityWithPieceInputProps) {
   const { getFieldProps } = useFormikContext<any>();
-  const isPcs = getFieldProps(unitName).value === "pcs";
+  const showPieceField =
+    getFieldProps(unitName).value === "pcs" && pieceUnit !== "pcs";
 
   return (
-    <div>
+    <div className="w-full min-w-0">
       <Label
         htmlFor={id}
         className={cn(
@@ -78,19 +79,19 @@ export function QuantityWithPieceInput({
         className="mt-1 flex items-center gap-1 text-xs text-destructive"
       />
 
-      {isPcs && (
-        <div className="mt-2 flex items-start gap-1.5 pl-1">
+      {showPieceField && (
+        <div className="mt-2 flex min-w-0 items-start gap-1.5 pl-1">
           <CornerDownRight
             className="mt-1.5 h-3.5 w-3.5 shrink-0 text-muted-foreground"
             aria-hidden
           />
-          <div className="flex-1">
+          <div className="min-w-0 flex-1">
             <span className="mb-1 block text-xs text-muted-foreground">
               {pieceLabel}
             </span>
             <div
               className={cn(
-                "flex items-center rounded-md border border-input bg-background",
+                "flex min-w-0 items-center rounded-md border border-input bg-background",
                 "ring-offset-background focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
                 inputClassName ?? "h-10",
               )}
@@ -103,7 +104,7 @@ export function QuantityWithPieceInput({
                 placeholder="0"
                 className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
               />
-              <div className="my-1 w-px self-stretch bg-input" />
+              <div className="my-1 w-px shrink-0 self-stretch bg-input" />
               <span className="shrink-0 px-2 text-sm font-medium text-foreground">
                 {pieceUnit}
               </span>

--- a/components/ui/value-unit-input.tsx
+++ b/components/ui/value-unit-input.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { ChevronDown } from "lucide-react";
+import { useFormikContext } from "formik";
+
+import { cn } from "@/lib/utils";
+import { SelectContent, SelectItem } from "@/components/ui/select";
+import { UNIT_OPTIONS } from "@/lib/constants/units";
+import type { UnitOption } from "@/types";
+
+interface ValueUnitInputProps {
+  value: string | number;
+  onValueChange: (value: string) => void;
+  unit: string;
+  onUnitChange: (unit: string) => void;
+  unitOptions?: UnitOption[];
+  placeholder?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+}
+
+export function ValueUnitInput({
+  value,
+  onValueChange,
+  unit,
+  onUnitChange,
+  unitOptions = UNIT_OPTIONS,
+  placeholder,
+  min,
+  max,
+  step,
+  disabled,
+  className,
+  id,
+}: ValueUnitInputProps) {
+  return (
+    <div
+      className={cn(
+        "flex h-10 items-center rounded-md border border-input bg-background ring-offset-background focus-within:outline-none focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+        disabled && "cursor-not-allowed opacity-50",
+        className,
+      )}
+    >
+      <input
+        id={id}
+        type="number"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={(e) => onValueChange(e.target.value)}
+        className="min-w-0 flex-1 bg-transparent px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none disabled:cursor-not-allowed [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+      />
+      <div className="w-px self-stretch bg-input my-1" />
+      <SelectPrimitive.Root
+        value={unit}
+        onValueChange={onUnitChange}
+        disabled={disabled}
+      >
+        <SelectPrimitive.Trigger
+          className={cn(
+            "flex items-center gap-0.5 rounded-r-md px-2 py-2 text-sm font-medium text-foreground focus:outline-none disabled:cursor-not-allowed data-[placeholder]:text-muted-foreground",
+            "min-w-[3rem] justify-center",
+          )}
+        >
+          <span className="shrink-0">{unit}</span>
+          <ChevronDown className="h-3 w-3 shrink-0 opacity-50" />
+        </SelectPrimitive.Trigger>
+        <SelectPrimitive.Portal>
+          <SelectContent>
+            {unitOptions.map((option) => (
+              <SelectItem key={option.value} value={option.value}>
+                {option.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </SelectPrimitive.Portal>
+      </SelectPrimitive.Root>
+    </div>
+  );
+}
+
+interface FormikValueUnitInputProps {
+  quantityName: string;
+  unitName: string;
+  unitOptions?: UnitOption[];
+  placeholder?: string;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+  className?: string;
+  id?: string;
+  onUnitChange?: (value: string) => void;
+}
+
+export function FormikValueUnitInput({
+  quantityName,
+  unitName,
+  unitOptions,
+  onUnitChange,
+  ...props
+}: FormikValueUnitInputProps) {
+  const { getFieldProps, setFieldValue } = useFormikContext<any>();
+  const quantityField = getFieldProps(quantityName);
+  const unitField = getFieldProps(unitName);
+
+  return (
+    <ValueUnitInput
+      value={quantityField.value ?? ""}
+      onValueChange={(val) => setFieldValue(quantityName, val)}
+      unit={unitField.value ?? ""}
+      onUnitChange={(val) => {
+        setFieldValue(unitName, val);
+        onUnitChange?.(val);
+      }}
+      unitOptions={unitOptions}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
This PR extracts repetitive quantity and unit input patterns into reusable components to reduce code duplication and improve maintainability across multiple dialogs.

## Key Changes

- **New Components Created:**
  - `FormikValueUnitInput`: A combined input component that integrates a number input with a unit selector dropdown, with built-in Formik integration
  - `QuantityWithPieceInput`: A higher-level component that wraps `FormikValueUnitInput` and conditionally displays a "per piece" sub-field when the unit is "pcs" and the paired quantity uses a different unit
  - `ValueUnitInput`: A presentational component underlying `FormikValueUnitInput` for non-Formik use cases

- **Refactored Dialogs:**
  - `add-recipe-dialog.tsx`: Replaced ~160 lines of manual quantity/unit field markup with two `QuantityWithPieceInput` components for prepared and serving quantities
  - `add-meal-dialog.tsx`: Applied the same refactoring pattern for recipe quantity inputs
  - `add-edit-menu-component-dialog.tsx`: Replaced quantity/unit and weight/unit field pairs with `FormikValueUnitInput` components, with proper unit change handlers
  - `ingredients-input.tsx`: Consolidated separate quantity and unit fields into a single `FormikValueUnitInput` component

- **Logic Improvements:**
  - Fixed `quantityPerPiece` serialization logic in `add-recipe-dialog.tsx` to properly handle cases where both prepared and serving quantities use "pcs" units
  - Enhanced unit change handlers in menu component dialog to properly reset weight-per-piece fields when switching away from piece-based units

- **API Response Handling:**
  - Updated `app/api/recipes/route.ts` to return proper `NextResponse.json()` with status codes instead of throwing errors

## Implementation Details

The new components support:
- Customizable unit options via `unitOptions` prop
- Flexible styling through `className`, `inputClassName`, and `labelClassName` props
- Formik integration with automatic field value synchronization
- Optional unit change callbacks for side effects (e.g., clearing dependent fields)
- Accessibility features (proper labels, error messages, ARIA attributes)

The `QuantityWithPieceInput` component intelligently shows the per-piece field only when one quantity uses "pcs" and the other doesn't, reducing UI clutter while maintaining necessary functionality.

https://claude.ai/code/session_0112Ms3wVeM5wYHj4quKssAp