### PR TITLE
Replace ErrorMessage component with conditional error rendering

### DIFF
--- a/components/dialogs/add-edit-menu-component-dialog.tsx
+++ b/components/dialogs/add-edit-menu-component-dialog.tsx
@@ -208,6 +208,7 @@ export function AddEditMenuComponentDialog({
           handleSubmit,
           isSubmitting,
           values,
+          errors,
           setFieldTouched,
           setFieldValue,
         }) => (
@@ -318,11 +319,11 @@ export function AddEditMenuComponentDialog({
                     </Button>
                   </div>
 
-                  <ErrorMessage
-                    name="averages"
-                    component="div"
-                    className="text-destructive text-xs"
-                  />
+                  {typeof errors.averages === "string" && (
+                    <div className="text-destructive text-xs">
+                      {errors.averages}
+                    </div>
+                  )}
 
                   {values.averages.map((average, index) => {
                     const usesPieces = average.unit === "pcs";


### PR DESCRIPTION
## Summary
Refactored error message handling in the AddEditMenuComponentDialog component by replacing the Formik `ErrorMessage` component with a conditional rendering approach.

## Key Changes
- Added `errors` to the destructured props from Formik's render function
- Replaced `<ErrorMessage>` component with a conditional `{typeof errors.averages === "string" && ...}` check
- Converted error display to a simple `<div>` with the same styling classes (`text-destructive text-xs`)

## Implementation Details
This change maintains the same visual output and error handling behavior while using a more explicit, conditional rendering pattern instead of relying on Formik's `ErrorMessage` component. The type check ensures that only string error messages are rendered, providing type safety for the error display.

https://claude.ai/code/session_01PdNDEoFcd1ww9PfAA1hL1w